### PR TITLE
Changed rotation calculations to use SafeNormalize

### DIFF
--- a/Projectiles/Celestial/BlackSilence/AtelierLogicGun1.cs
+++ b/Projectiles/Celestial/BlackSilence/AtelierLogicGun1.cs
@@ -101,12 +101,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Celestial/BlackSilence/AtelierLogicGun2.cs
+++ b/Projectiles/Celestial/BlackSilence/AtelierLogicGun2.cs
@@ -101,12 +101,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Celestial/BlackSilence/AtelierLogicGun3.cs
+++ b/Projectiles/Celestial/BlackSilence/AtelierLogicGun3.cs
@@ -92,12 +92,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Celestial/BlackSilence/DurandalHeld.cs
+++ b/Projectiles/Celestial/BlackSilence/DurandalHeld.cs
@@ -94,12 +94,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Celestial/BlackSilence/DurandalSlash1.cs
+++ b/Projectiles/Celestial/BlackSilence/DurandalSlash1.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Celestial/BlackSilence/DurandalSlash2.cs
+++ b/Projectiles/Celestial/BlackSilence/DurandalSlash2.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Celestial/BlackSilence/MookHeldSheathe.cs
+++ b/Projectiles/Celestial/BlackSilence/MookHeldSheathe.cs
@@ -95,12 +95,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Celestial/BlackSilence/RangaHeld.cs
+++ b/Projectiles/Celestial/BlackSilence/RangaHeld.cs
@@ -101,12 +101,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Celestial/BlackSilence/WheelsIndustryAttack.cs
+++ b/Projectiles/Celestial/BlackSilence/WheelsIndustryAttack.cs
@@ -111,12 +111,12 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Celestial/BlackSilence/ZelkovaSlash1.cs
+++ b/Projectiles/Celestial/BlackSilence/ZelkovaSlash1.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Celestial/BlackSilence/ZelkovaSlash2.cs
+++ b/Projectiles/Celestial/BlackSilence/ZelkovaSlash2.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Celestial/BlackSilence/ZelkovaSlash3.cs
+++ b/Projectiles/Celestial/BlackSilence/ZelkovaSlash3.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Celestial/BlackSilence/ZelkovaSlash4.cs
+++ b/Projectiles/Celestial/BlackSilence/ZelkovaSlash4.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Celestial.BlackSilence
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Celestial/BuryTheLight/BuryTheLightSheathe.cs
+++ b/Projectiles/Celestial/BuryTheLight/BuryTheLightSheathe.cs
@@ -95,12 +95,12 @@ namespace StarsAbove.Projectiles.Celestial.BuryTheLight
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Celestial/BuryTheLight/MirageBlade.cs
+++ b/Projectiles/Celestial/BuryTheLight/MirageBlade.cs
@@ -118,7 +118,7 @@ namespace StarsAbove.Projectiles.Celestial.BuryTheLight
                 //Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
                 //Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-                //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
                 //Projectile.rotation = MathHelper.ToRadians(90f);
                 Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(90f);
 

--- a/Projectiles/Celestial/BuryTheLight/MirageBladeAlt.cs
+++ b/Projectiles/Celestial/BuryTheLight/MirageBladeAlt.cs
@@ -117,7 +117,7 @@ namespace StarsAbove.Projectiles.Celestial.BuryTheLight
                 //Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
                 //Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-                //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
                 //Projectile.rotation = MathHelper.ToRadians(90f);
                 Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(90f);
 

--- a/Projectiles/Celestial/CatalystMemory/CatalystHeldBlade.cs
+++ b/Projectiles/Celestial/CatalystMemory/CatalystHeldBlade.cs
@@ -157,12 +157,12 @@ namespace StarsAbove.Projectiles.Celestial.CatalystMemory
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Celestial/EverlastingPickaxe/EverlastingPickaxeSwing1.cs
+++ b/Projectiles/Celestial/EverlastingPickaxe/EverlastingPickaxeSwing1.cs
@@ -88,7 +88,7 @@ namespace StarsAbove.Projectiles.Celestial.EverlastingPickaxe
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
 
 
 

--- a/Projectiles/Celestial/EverlastingPickaxe/EverlastingPickaxeSwing2.cs
+++ b/Projectiles/Celestial/EverlastingPickaxe/EverlastingPickaxeSwing2.cs
@@ -107,7 +107,7 @@ namespace StarsAbove.Projectiles.Celestial.EverlastingPickaxe
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(135f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(135f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Celestial/TheOnlyThingIKnowForReal/GuntriggerParry.cs
+++ b/Projectiles/Celestial/TheOnlyThingIKnowForReal/GuntriggerParry.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Celestial.TheOnlyThingIKnowForReal
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlash1.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlash1.cs
@@ -93,7 +93,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlash2.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlash2.cs
@@ -111,7 +111,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlashVoid.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueEdgeSlashVoid.cs
@@ -80,7 +80,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueVFX1.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueVFX1.cs
@@ -83,7 +83,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueVFX2.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueVFX2.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Celestial/VirtuesEdge/VirtueVFXVoid.cs
+++ b/Projectiles/Celestial/VirtuesEdge/VirtueVFXVoid.cs
@@ -98,7 +98,7 @@ namespace StarsAbove.Projectiles.Celestial.VirtuesEdge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Generics/StarsAboveGun.cs
+++ b/Projectiles/Generics/StarsAboveGun.cs
@@ -287,7 +287,7 @@ namespace StarsAbove.Projectiles.Generics
         }
         private void OrientSprite(Player projOwner)
         {
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             
             //Main.NewText(MathHelper.ToDegrees(Projectile.rotation));
             if (Projectile.rotation >= MathHelper.ToRadians(90) && Projectile.rotation <= MathHelper.ToRadians(270))

--- a/Projectiles/Generics/StarsAboveSword.cs
+++ b/Projectiles/Generics/StarsAboveSword.cs
@@ -351,12 +351,12 @@ namespace StarsAbove.Projectiles.Generics
                     {
                         if (Projectile.ai[1] == 1)
                         {
-                            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-45f);
+                            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-45f);
 
                         }
                         else
                         {
-                            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-135f);
+                            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-135f);
 
                         }
                     }
@@ -364,12 +364,12 @@ namespace StarsAbove.Projectiles.Generics
                     {
                         if (Projectile.ai[1] == 1)
                         {
-                            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-135f);
+                            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-135f);
 
                         }
                         else
                         {
-                            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-45f);
+                            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-45f);
 
                         }
                     }
@@ -378,7 +378,7 @@ namespace StarsAbove.Projectiles.Generics
                 }
                 else
                 {
-                    Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+                    Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
                 }
 
@@ -389,13 +389,13 @@ namespace StarsAbove.Projectiles.Generics
                 {
                     if (Projectile.ai[1] == 1)
                     {
-                        Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+                        Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
 
                     }
                     else
                     {
-                        Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-135f);
+                        Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-135f);
 
                     }
 

--- a/Projectiles/Magic/Ozma/OzmaAttack3.cs
+++ b/Projectiles/Magic/Ozma/OzmaAttack3.cs
@@ -124,7 +124,7 @@ namespace StarsAbove.Projectiles.Magic.Ozma
         {
             //for (int d = 0; d < 8; d++)
             {
-                Dust.NewDust(Projectile.Center, 0, 0, ProjectileID.DiamondBolt, Main.rand.NextFloat(-7, 7), Main.rand.NextFloat(-7, 7), 150, default, 0.9f);
+                Dust.NewDust(Projectile.Center, 0, 0, DustID.GemDiamond, Main.rand.NextFloat(-7, 7), Main.rand.NextFloat(-7, 7), 150, default, 0.9f);
 
             }
         }

--- a/Projectiles/Magic/RedMage/RedMageRapier.cs
+++ b/Projectiles/Magic/RedMage/RedMageRapier.cs
@@ -154,7 +154,7 @@ namespace StarsAbove.Projectiles.Magic.RedMage
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Magic/RedMage/RedMageRapierFast.cs
+++ b/Projectiles/Magic/RedMage/RedMageRapierFast.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Magic.RedMage
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Magic/RedMage/ResolutionMagicCircle.cs
+++ b/Projectiles/Magic/RedMage/ResolutionMagicCircle.cs
@@ -139,7 +139,7 @@ namespace StarsAbove.Projectiles.Magic.RedMage
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Magic/RedMage/ResolutionMagicCircle2.cs
+++ b/Projectiles/Magic/RedMage/ResolutionMagicCircle2.cs
@@ -87,7 +87,7 @@ namespace StarsAbove.Projectiles.Magic.RedMage
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Magic/SupremeAuthority/AuthoritySwing1.cs
+++ b/Projectiles/Magic/SupremeAuthority/AuthoritySwing1.cs
@@ -94,7 +94,7 @@ namespace StarsAbove.Projectiles.Magic.SupremeAuthority
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Magic/SupremeAuthority/AuthoritySwing2.cs
+++ b/Projectiles/Magic/SupremeAuthority/AuthoritySwing2.cs
@@ -112,7 +112,7 @@ namespace StarsAbove.Projectiles.Magic.SupremeAuthority
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Magic/SupremeAuthority/AuthorityVFX1.cs
+++ b/Projectiles/Magic/SupremeAuthority/AuthorityVFX1.cs
@@ -83,7 +83,7 @@ namespace StarsAbove.Projectiles.Magic.SupremeAuthority
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Magic/SupremeAuthority/AuthorityVFX2.cs
+++ b/Projectiles/Magic/SupremeAuthority/AuthorityVFX2.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Magic.SupremeAuthority
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Magic/VermillionDaemon/VermillionSlash1.cs
+++ b/Projectiles/Magic/VermillionDaemon/VermillionSlash1.cs
@@ -86,7 +86,7 @@ namespace StarsAbove.Projectiles.Magic.VermillionDaemon
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
 
 
 

--- a/Projectiles/Magic/VermillionDaemon/VermillionSlash2.cs
+++ b/Projectiles/Magic/VermillionDaemon/VermillionSlash2.cs
@@ -106,7 +106,7 @@ namespace StarsAbove.Projectiles.Magic.VermillionDaemon
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(135f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(135f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Magic/VermillionDaemon/VermillionSlash3.cs
+++ b/Projectiles/Magic/VermillionDaemon/VermillionSlash3.cs
@@ -88,7 +88,7 @@ namespace StarsAbove.Projectiles.Magic.VermillionDaemon
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
 
 
 

--- a/Projectiles/Melee/BloodBlade/BloodArtPrep.cs
+++ b/Projectiles/Melee/BloodBlade/BloodArtPrep.cs
@@ -98,10 +98,9 @@ namespace StarsAbove.Projectiles.Melee.BloodBlade
             float rotationsPerSecond = rotationSpeed;
             rotationSpeed -= 0.1f;
             bool rotateClockwise = true;
+
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
-
-
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
         }
 
         public override void OnKill(int timeLeft)

--- a/Projectiles/Melee/BloodBlade/BloodSlash1.cs
+++ b/Projectiles/Melee/BloodBlade/BloodSlash1.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Melee.BloodBlade
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/BloodBlade/BloodSlash2.cs
+++ b/Projectiles/Melee/BloodBlade/BloodSlash2.cs
@@ -104,7 +104,7 @@ namespace StarsAbove.Projectiles.Melee.BloodBlade
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/BurningDesire/BoilingBurstPrep1.cs
+++ b/Projectiles/Melee/BurningDesire/BoilingBurstPrep1.cs
@@ -98,7 +98,7 @@ namespace StarsAbove.Projectiles.Melee.BurningDesire
             rotationSpeed -= 0.1f;
             bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
 
         }

--- a/Projectiles/Melee/BurningDesire/BoilingBurstPrep2.cs
+++ b/Projectiles/Melee/BurningDesire/BoilingBurstPrep2.cs
@@ -95,7 +95,7 @@ namespace StarsAbove.Projectiles.Melee.BurningDesire
             rotationSpeed -= 0.1f;
             bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
 
         }

--- a/Projectiles/Melee/BurningDesire/BurningDesireSlash1.cs
+++ b/Projectiles/Melee/BurningDesire/BurningDesireSlash1.cs
@@ -100,7 +100,7 @@ namespace StarsAbove.Projectiles.Melee.BurningDesire
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/BurningDesire/BurningDesireSlash2.cs
+++ b/Projectiles/Melee/BurningDesire/BurningDesireSlash2.cs
@@ -100,7 +100,7 @@ namespace StarsAbove.Projectiles.Melee.BurningDesire
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/Hullwrought/HullwroughtSpin.cs
+++ b/Projectiles/Melee/Hullwrought/HullwroughtSpin.cs
@@ -108,7 +108,7 @@ namespace StarsAbove.Projectiles.Melee.Hullwrought
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
             if (Main.rand.NextBool(3))

--- a/Projectiles/Melee/Hullwrought/HullwroughtSpin2.cs
+++ b/Projectiles/Melee/Hullwrought/HullwroughtSpin2.cs
@@ -108,7 +108,7 @@ namespace StarsAbove.Projectiles.Melee.Hullwrought
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
             if (Main.rand.NextBool(3))

--- a/Projectiles/Melee/Hullwrought/HullwroughtSpinDamage.cs
+++ b/Projectiles/Melee/Hullwrought/HullwroughtSpinDamage.cs
@@ -104,7 +104,7 @@ namespace StarsAbove.Projectiles.Melee.Hullwrought
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/RebellionBloodArthur/RebellionSwordLaser.cs
+++ b/Projectiles/Melee/RebellionBloodArthur/RebellionSwordLaser.cs
@@ -71,7 +71,7 @@ namespace StarsAbove.Projectiles.Melee.RebellionBloodArthur
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
 
 

--- a/Projectiles/Melee/RebellionBloodArthur/RebellionTarget.cs
+++ b/Projectiles/Melee/RebellionBloodArthur/RebellionTarget.cs
@@ -98,7 +98,7 @@ namespace StarsAbove.Projectiles.Melee.RebellionBloodArthur
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashCooling1.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashCooling1.cs
@@ -86,7 +86,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashCooling2.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashCooling2.cs
@@ -110,7 +110,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashEarth1.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashEarth1.cs
@@ -87,7 +87,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashEarth2.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashEarth2.cs
@@ -111,7 +111,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashHeaven1.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashHeaven1.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashHeaven2.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashHeaven2.cs
@@ -110,7 +110,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashVolcano1.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashVolcano1.cs
@@ -86,7 +86,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/SakuraVengeance/SakuraSlashVolcano2.cs
+++ b/Projectiles/Melee/SakuraVengeance/SakuraSlashVolcano2.cs
@@ -110,7 +110,7 @@ namespace StarsAbove.Projectiles.Melee.SakuraVengeance
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/SoulReaver/SoulReaverSlash1.cs
+++ b/Projectiles/Melee/SoulReaver/SoulReaverSlash1.cs
@@ -86,7 +86,7 @@ namespace StarsAbove.Projectiles.Melee.SoulReaver
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(25f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(25f);
 
 
 

--- a/Projectiles/Melee/SoulReaver/SoulReaverSlash2.cs
+++ b/Projectiles/Melee/SoulReaver/SoulReaverSlash2.cs
@@ -106,7 +106,7 @@ namespace StarsAbove.Projectiles.Melee.SoulReaver
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(335f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(335f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/SoulReaver/SoulReaverVFX1.cs
+++ b/Projectiles/Melee/SoulReaver/SoulReaverVFX1.cs
@@ -92,7 +92,7 @@ namespace StarsAbove.Projectiles.Melee.SoulReaver
             bool rotateClockwise = true;
 
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Melee/SoulReaver/SoulReaverVFX2.cs
+++ b/Projectiles/Melee/SoulReaver/SoulReaverVFX2.cs
@@ -88,7 +88,7 @@ namespace StarsAbove.Projectiles.Melee.SoulReaver
             bool rotateClockwise = true;
 
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Melee/SoulReaver/SoulReaverVFX3.cs
+++ b/Projectiles/Melee/SoulReaver/SoulReaverVFX3.cs
@@ -90,7 +90,7 @@ namespace StarsAbove.Projectiles.Melee.SoulReaver
             bool rotateClockwise = true;
 
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Melee/Umbra/UmbraSlash1.cs
+++ b/Projectiles/Melee/Umbra/UmbraSlash1.cs
@@ -88,7 +88,7 @@ namespace StarsAbove.Projectiles.Melee.Umbra
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Melee/Umbra/UmbraSlash2.cs
+++ b/Projectiles/Melee/Umbra/UmbraSlash2.cs
@@ -108,7 +108,7 @@ namespace StarsAbove.Projectiles.Melee.Umbra
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Melee/Umbra/UmbraSlashSlow.cs
+++ b/Projectiles/Melee/Umbra/UmbraSlashSlow.cs
@@ -85,7 +85,7 @@ namespace StarsAbove.Projectiles.Melee.Umbra
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Other/ArchitectLuminance/ArchitectShoot.cs
+++ b/Projectiles/Other/ArchitectLuminance/ArchitectShoot.cs
@@ -67,7 +67,7 @@ namespace StarsAbove.Projectiles.Other.ArchitectLuminance
             }
             // Apply proper rotation, with an offset of 135 degrees due to the sprite's rotation, notice the usage of MathHelper, use this class!
             // MathHelper.ToRadians(xx degrees here)
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(135f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(135f);
             // Offset by 90 degrees here
             if (Projectile.spriteDirection == -1)
             {

--- a/Projectiles/Other/DreadmotherDarkIdol/DreadmotherEnergyBall.cs
+++ b/Projectiles/Other/DreadmotherDarkIdol/DreadmotherEnergyBall.cs
@@ -134,7 +134,7 @@ namespace StarsAbove.Projectiles.Other.DreadmotherDarkIdol
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Other/DreadmotherDarkIdol/DreadmotherMagicOrbitals.cs
+++ b/Projectiles/Other/DreadmotherDarkIdol/DreadmotherMagicOrbitals.cs
@@ -130,7 +130,7 @@ namespace StarsAbove.Projectiles.Other.DreadmotherDarkIdol
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
 
         }

--- a/Projectiles/Other/DreadmotherDarkIdol/DreadmotherMagicSpheresCenter.cs
+++ b/Projectiles/Other/DreadmotherDarkIdol/DreadmotherMagicSpheresCenter.cs
@@ -106,7 +106,7 @@ namespace StarsAbove.Projectiles.Other.DreadmotherDarkIdol
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Other/DreadmotherDarkIdol/DreadmotherStaff.cs
+++ b/Projectiles/Other/DreadmotherDarkIdol/DreadmotherStaff.cs
@@ -92,7 +92,7 @@ namespace StarsAbove.Projectiles.Other.DreadmotherDarkIdol
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Other/GoldenKatana/GoldenKatanaHeld.cs
+++ b/Projectiles/Other/GoldenKatana/GoldenKatanaHeld.cs
@@ -198,12 +198,12 @@ namespace StarsAbove.Projectiles.Other.GoldenKatana
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Other/GoldenKatana/GoldenKatanaSheath.cs
+++ b/Projectiles/Other/GoldenKatana/GoldenKatanaSheath.cs
@@ -95,12 +95,12 @@ namespace StarsAbove.Projectiles.Other.GoldenKatana
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Other/GoldenKatana/GoldenKatanaSwing1.cs
+++ b/Projectiles/Other/GoldenKatana/GoldenKatanaSwing1.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Other.GoldenKatana
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //player.itemRotation = Projectile.rotation;
 
 

--- a/Projectiles/Other/GoldenKatana/GoldenKatanaSwing2.cs
+++ b/Projectiles/Other/GoldenKatana/GoldenKatanaSwing2.cs
@@ -108,7 +108,7 @@ namespace StarsAbove.Projectiles.Other.GoldenKatana
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Other/LevinstormAxe/LevinstormAxe1.cs
+++ b/Projectiles/Other/LevinstormAxe/LevinstormAxe1.cs
@@ -91,7 +91,7 @@ namespace StarsAbove.Projectiles.Other.LevinstormAxe
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Other/LevinstormAxe/LevinstormAxe2.cs
+++ b/Projectiles/Other/LevinstormAxe/LevinstormAxe2.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Other.LevinstormAxe
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Other/LevinstormAxe/LevinstormVFX1.cs
+++ b/Projectiles/Other/LevinstormAxe/LevinstormVFX1.cs
@@ -83,7 +83,7 @@ namespace StarsAbove.Projectiles.Other.LevinstormAxe
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Other/LevinstormAxe/LevinstormVFX2.cs
+++ b/Projectiles/Other/LevinstormAxe/LevinstormVFX2.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Other.LevinstormAxe
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Other/Manifestation/ManifestationHeld.cs
+++ b/Projectiles/Other/Manifestation/ManifestationHeld.cs
@@ -103,13 +103,13 @@ namespace StarsAbove.Projectiles.Other.Manifestation
                 {//Adjust when facing the other direction
                     Projectile.position.X = projOwner.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2 + 19;
                     Projectile.position.Y = projOwner.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2 - 20 + projOwner.velocity.Y * 0.05f;
-                    Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(100f);
+                    Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(100f);
                 }
                 else
                 {
                     Projectile.position.X = projOwner.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2 - 19;
                     Projectile.position.Y = projOwner.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2 - 20 + projOwner.velocity.Y * 0.05f;
-                    Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(80f);
+                    Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(80f);
                 }
             }
             else
@@ -147,12 +147,12 @@ namespace StarsAbove.Projectiles.Other.Manifestation
                 if (Projectile.spriteDirection == 1)
                 {//Adjust when facing the other direction
 
-                    Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                    Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
                 }
                 else
                 {
 
-                    Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                    Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
                 }
                 Projectile.rotation += projOwner.velocity.X * 0.05f; //Rotate in the direction of the user when moving
 

--- a/Projectiles/Other/Manifestation/ManifestationSwordSlash1.cs
+++ b/Projectiles/Other/Manifestation/ManifestationSwordSlash1.cs
@@ -98,7 +98,7 @@ namespace StarsAbove.Projectiles.Other.Manifestation
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Other/Manifestation/ManifestationSwordSlash2.cs
+++ b/Projectiles/Other/Manifestation/ManifestationSwordSlash2.cs
@@ -122,7 +122,7 @@ namespace StarsAbove.Projectiles.Other.Manifestation
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Other/SunsetOfTheSunGod/KarnaChargedMelee.cs
+++ b/Projectiles/Other/SunsetOfTheSunGod/KarnaChargedMelee.cs
@@ -91,7 +91,7 @@ namespace StarsAbove.Projectiles.Other.SunsetOfTheSunGod
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Other/SunsetOfTheSunGod/KarnaChargedMeleeVFX.cs
+++ b/Projectiles/Other/SunsetOfTheSunGod/KarnaChargedMeleeVFX.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Other.SunsetOfTheSunGod
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //Projectile.rotation = MathHelper.ToRadians(90f);
             Projectile.rotation = MathHelper.ToRadians(0f);
 

--- a/Projectiles/Other/SunsetOfTheSunGod/KarnaLightningSpear.cs
+++ b/Projectiles/Other/SunsetOfTheSunGod/KarnaLightningSpear.cs
@@ -115,7 +115,7 @@ namespace StarsAbove.Projectiles.Other.SunsetOfTheSunGod
                 Projectile.position.X = player.GetModPlayer<StarsAbovePlayer>().playerMousePos.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
                 Projectile.position.Y = player.GetModPlayer<StarsAbovePlayer>().playerMousePos.Y - (int)(Math.Sin(rad) * dist) / 7 - 400;
 
-                //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
                 //Projectile.rotation = MathHelper.ToRadians(90f);
                 Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
 

--- a/Projectiles/Other/SunsetOfTheSunGod/KarnaLightningSpearAlt.cs
+++ b/Projectiles/Other/SunsetOfTheSunGod/KarnaLightningSpearAlt.cs
@@ -117,7 +117,7 @@ namespace StarsAbove.Projectiles.Other.SunsetOfTheSunGod
                 Projectile.position.X = player.GetModPlayer<StarsAbovePlayer>().playerMousePos.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
                 Projectile.position.Y = player.GetModPlayer<StarsAbovePlayer>().playerMousePos.Y - (int)(Math.Sin(rad) * dist) / 7 - 400;
 
-                //Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                //Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
                 //Projectile.rotation = MathHelper.ToRadians(90f);
                 Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
 

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker1.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker1.cs
@@ -134,7 +134,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker2.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker2.cs
@@ -137,7 +137,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker3.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker3.cs
@@ -137,7 +137,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker4.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker4.cs
@@ -137,7 +137,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker5.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker5.cs
@@ -137,7 +137,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/Chemtank/ChemtankMarker6.cs
+++ b/Projectiles/Ranged/Chemtank/ChemtankMarker6.cs
@@ -137,7 +137,7 @@ namespace StarsAbove.Projectiles.Ranged.Chemtank
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]--;
 
             if (Projectile.ai[0] > 0)

--- a/Projectiles/Ranged/InheritedCaseM4A1/M16A1Shield.cs
+++ b/Projectiles/Ranged/InheritedCaseM4A1/M16A1Shield.cs
@@ -117,7 +117,7 @@ namespace StarsAbove.Projectiles.Ranged.InheritedCaseM4A1
             Projectile.position.X = projOwner.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = projOwner.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
 
 
 

--- a/Projectiles/Ranged/InheritedCaseM4A1/StarsAboveGunM4A1.cs
+++ b/Projectiles/Ranged/InheritedCaseM4A1/StarsAboveGunM4A1.cs
@@ -285,7 +285,7 @@ namespace StarsAbove.Projectiles.Ranged.InheritedCaseM4A1
         }
         private void OrientSprite(Player projOwner)
         {
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             
             //Main.NewText(MathHelper.ToDegrees(Projectile.rotation));
             if (Projectile.rotation >= MathHelper.ToRadians(90) && Projectile.rotation <= MathHelper.ToRadians(270))

--- a/Projectiles/Ranged/KissOfDeath/KissOfDeathMinigun.cs
+++ b/Projectiles/Ranged/KissOfDeath/KissOfDeathMinigun.cs
@@ -63,12 +63,12 @@ namespace StarsAbove.Projectiles.Ranged.KissOfDeath
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             return base.PreAI();

--- a/Projectiles/Ranged/SaltwaterScourge/SaltwaterGun.cs
+++ b/Projectiles/Ranged/SaltwaterScourge/SaltwaterGun.cs
@@ -101,12 +101,12 @@ namespace StarsAbove.Projectiles.Ranged.SaltwaterScourge
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
             //Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/Ranged/SaltwaterScourge/SaltwaterSlash1.cs
+++ b/Projectiles/Ranged/SaltwaterScourge/SaltwaterSlash1.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Ranged.SaltwaterScourge
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Ranged/SaltwaterScourge/SaltwaterSlash2.cs
+++ b/Projectiles/Ranged/SaltwaterScourge/SaltwaterSlash2.cs
@@ -105,7 +105,7 @@ namespace StarsAbove.Projectiles.Ranged.SaltwaterScourge
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Ranged/ShockAndAwe/GardenerSlash1.cs
+++ b/Projectiles/Ranged/ShockAndAwe/GardenerSlash1.cs
@@ -88,7 +88,7 @@ namespace StarsAbove.Projectiles.Ranged.ShockAndAwe
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 
 
 

--- a/Projectiles/Ranged/ShockAndAwe/GardenerSlash2.cs
+++ b/Projectiles/Ranged/ShockAndAwe/GardenerSlash2.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Ranged.ShockAndAwe
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Ranged/TwoCrownBow/TwoCrownBowLaserPreVFX2.cs
+++ b/Projectiles/Ranged/TwoCrownBow/TwoCrownBowLaserPreVFX2.cs
@@ -111,7 +111,7 @@ namespace StarsAbove.Projectiles.Ranged.TwoCrownBow
             float offset = (float)Math.Sin(Main.GlobalTimeWrappedHourly * TwoPi / 5f);
             Vector2 drawPos = Projectile.Center - Main.screenPosition;
 
-            float rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation();
+            float rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation();
             // Draw the main texture
 
             Main.EntitySpriteDraw(texture, drawPos, frame, color, rotation, origin, 0.7f, SpriteEffects.None, 0f);

--- a/Projectiles/Ranged/TwoCrownBow/TwoCrownBowLaserPreVFX3.cs
+++ b/Projectiles/Ranged/TwoCrownBow/TwoCrownBowLaserPreVFX3.cs
@@ -116,7 +116,7 @@ namespace StarsAbove.Projectiles.Ranged.TwoCrownBow
             Vector2 drawPos3 = Vector2.Lerp(Projectile.Center, Main.player[Projectile.owner].Center, 0.45f + bonusEase) - Main.screenPosition;
             Vector2 drawPos4 = Vector2.Lerp(Projectile.Center, Main.player[Projectile.owner].Center, 0.25f + bonusEase) - Main.screenPosition;
 
-            float rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation();
+            float rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation();
             // Draw the main texture
 
             Main.EntitySpriteDraw(texture, drawPos, frame, color, rotation, origin, 0.9f + MathHelper.Lerp(0f, 1f, EaseHelper.InOutQuad((float)((float)Projectile.alpha / 205f))), SpriteEffects.None, 0f);

--- a/Projectiles/Ranged/TwoCrownBow/TwoCrownBowSkyAttack.cs
+++ b/Projectiles/Ranged/TwoCrownBow/TwoCrownBowSkyAttack.cs
@@ -92,7 +92,7 @@ namespace StarsAbove.Projectiles.Ranged.TwoCrownBow
                 Main.projectile[index].originalDamage = Projectile.damage;
 
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Ranged/TwoCrownBow/TwoCrownVFX.cs
+++ b/Projectiles/Ranged/TwoCrownBow/TwoCrownVFX.cs
@@ -120,7 +120,7 @@ namespace StarsAbove.Projectiles.Ranged.TwoCrownBow
             float offset = (float)Math.Sin(Main.GlobalTimeWrappedHourly * TwoPi / 5f);
             Vector2 drawPos = Projectile.Center - Main.screenPosition;
 
-            float rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation();
+            float rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation();
             // Draw the main texture
             Main.EntitySpriteDraw(texture, drawPos, frame, color, rotation, origin, 0.7f, effects, 0f);
 

--- a/Projectiles/StellarNovas/GuardiansLight/GoldenGunHeld.cs
+++ b/Projectiles/StellarNovas/GuardiansLight/GoldenGunHeld.cs
@@ -141,12 +141,12 @@ namespace StarsAbove.Projectiles.StellarNovas.GuardiansLight
 			if (Projectile.spriteDirection == 1)
 			{//Adjust when facing the other direction
 
-				Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+				Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
 			}
 			else
 			{
 
-				Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+				Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 			}
 			//Projectile.Center += projOwner.gfxOffY * Vector2.UnitY;//Prevent glitchy animation.
 

--- a/Projectiles/StellarNovas/UBWBladeFollowUp.cs
+++ b/Projectiles/StellarNovas/UBWBladeFollowUp.cs
@@ -129,7 +129,7 @@ namespace StarsAbove.Projectiles.StellarNovas
 				Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
 				Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-				//Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+				//Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 				//Projectile.rotation = MathHelper.ToRadians(90f);
 				Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(45f);
 

--- a/Projectiles/StellarNovas/UBWBladeFollowUpDelay.cs
+++ b/Projectiles/StellarNovas/UBWBladeFollowUpDelay.cs
@@ -129,7 +129,7 @@ namespace StarsAbove.Projectiles.StellarNovas
 				Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
 				Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-				//Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+				//Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
 				//Projectile.rotation = MathHelper.ToRadians(90f);
 				Projectile.rotation = Vector2.Normalize(player.GetModPlayer<StarsAbovePlayer>().playerMousePos - Projectile.Center).ToRotation() + MathHelper.ToRadians(45f);
 

--- a/Projectiles/Summon/CaesuraOfDespair/IrysCrystal1.cs
+++ b/Projectiles/Summon/CaesuraOfDespair/IrysCrystal1.cs
@@ -109,7 +109,7 @@ namespace StarsAbove.Projectiles.Summon.CaesuraOfDespair
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Summon/CaesuraOfDespair/IrysCrystal2.cs
+++ b/Projectiles/Summon/CaesuraOfDespair/IrysCrystal2.cs
@@ -111,7 +111,7 @@ namespace StarsAbove.Projectiles.Summon.CaesuraOfDespair
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
             //The rotation is set here
             //projectile.rotation += (rotateClockwise ? 1 : -1) * MathHelper.ToRadians(rotationsPerSecond * 6f);

--- a/Projectiles/Summon/CaesuraOfDespair/IrysCrystal3.cs
+++ b/Projectiles/Summon/CaesuraOfDespair/IrysCrystal3.cs
@@ -112,7 +112,7 @@ namespace StarsAbove.Projectiles.Summon.CaesuraOfDespair
 
                 }
             }
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
 
             Projectile.ai[0]++;
             //The rotation is set here

--- a/Projectiles/Summon/Kifrosse/BlizzardFoxfire1.cs
+++ b/Projectiles/Summon/Kifrosse/BlizzardFoxfire1.cs
@@ -164,7 +164,7 @@ namespace StarsAbove.Projectiles.Summon.Kifrosse
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
             if (player.HasBuff(BuffType<AmaterasuWinter>()))
             {

--- a/Projectiles/Summon/Kifrosse/BlizzardFoxfire2.cs
+++ b/Projectiles/Summon/Kifrosse/BlizzardFoxfire2.cs
@@ -165,7 +165,7 @@ namespace StarsAbove.Projectiles.Summon.Kifrosse
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
             if (player.HasBuff(BuffType<AmaterasuWinter>()))
             {

--- a/Projectiles/Summon/Kifrosse/BlizzardFoxfire3.cs
+++ b/Projectiles/Summon/Kifrosse/BlizzardFoxfire3.cs
@@ -165,7 +165,7 @@ namespace StarsAbove.Projectiles.Summon.Kifrosse
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
             if (player.HasBuff(BuffType<AmaterasuWinter>()))
             {

--- a/Projectiles/Summon/Kifrosse/DancingFoxfire1.cs
+++ b/Projectiles/Summon/Kifrosse/DancingFoxfire1.cs
@@ -164,7 +164,7 @@ namespace StarsAbove.Projectiles.Summon.Kifrosse
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Summon/Kifrosse/DancingFoxfire2.cs
+++ b/Projectiles/Summon/Kifrosse/DancingFoxfire2.cs
@@ -163,7 +163,7 @@ namespace StarsAbove.Projectiles.Summon.Kifrosse
 
 
             }
-            //projectile.rotation = Vector2.Normalize(Main.player[projectile.owner].Center - projectile.Center).ToRotation() + MathHelper.ToRadians(-90f);
+            //projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(-90f);
             Projectile.ai[0]++;
 
 

--- a/Projectiles/Summon/KroniicPrincipality/TemporalTimepiece2.cs
+++ b/Projectiles/Summon/KroniicPrincipality/TemporalTimepiece2.cs
@@ -75,7 +75,7 @@ namespace StarsAbove.Projectiles.Summon.KroniicPrincipality
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
             /*if (Main.rand.NextBool(3))

--- a/Projectiles/Summon/KroniicPrincipality/TemporalTimepiece3.cs
+++ b/Projectiles/Summon/KroniicPrincipality/TemporalTimepiece3.cs
@@ -77,7 +77,7 @@ namespace StarsAbove.Projectiles.Summon.KroniicPrincipality
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
             /*if (Main.rand.NextBool(3))

--- a/Projectiles/Summon/RupturedHeaven/RupturedSwing1.cs
+++ b/Projectiles/Summon/RupturedHeaven/RupturedSwing1.cs
@@ -84,7 +84,7 @@ namespace StarsAbove.Projectiles.Summon.RupturedHeaven
             Projectile.position.X = player.Center.X - (int)(Math.Cos(rad) * dist) - Projectile.width / 2;
             Projectile.position.Y = player.Center.Y - (int)(Math.Sin(rad) * dist) - Projectile.height / 2;
 
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(225f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(225f);
 
 
 

--- a/Projectiles/Summon/RupturedHeaven/RupturedSwing2.cs
+++ b/Projectiles/Summon/RupturedHeaven/RupturedSwing2.cs
@@ -105,7 +105,7 @@ namespace StarsAbove.Projectiles.Summon.RupturedHeaven
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(135f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(135f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
 

--- a/Projectiles/Summon/Youmu/YoumuHeld.cs
+++ b/Projectiles/Summon/Youmu/YoumuHeld.cs
@@ -95,12 +95,12 @@ namespace StarsAbove.Projectiles.Summon.Youmu
             if (Projectile.spriteDirection == 1)
             {//Adjust when facing the other direction
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             }
             else
             {
 
-                Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(0f);
+                Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(0f);
             }
 
             Projectile.ai[0]++;

--- a/Projectiles/Summon/Youmu/YoumuSpin.cs
+++ b/Projectiles/Summon/Youmu/YoumuSpin.cs
@@ -113,7 +113,7 @@ namespace StarsAbove.Projectiles.Summon.Youmu
             //rotationSpeed -= 1f;
             //bool rotateClockwise = true;
             //The rotation is set here
-            Projectile.rotation = Vector2.Normalize(Main.player[Projectile.owner].Center - Projectile.Center).ToRotation() + MathHelper.ToRadians(180f);
+            Projectile.rotation = (Main.player[Projectile.owner].Center - Projectile.Center).SafeNormalize(Vector2.Zero).ToRotation() + MathHelper.ToRadians(180f);
             //projectile.rotation = projectile.velocity.ToRotation();
 
         }

--- a/StarsAbove.csproj
+++ b/StarsAbove.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>StarsAbove</AssemblyName>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>


### PR DESCRIPTION
Changed projectile rotation calculations across the entire mod. This prevents NaNs getting set to the projectile's rotation field. This prevents NaNs from entering critical drawing code that would lock the game and consume unlimited amounts of RAM. 